### PR TITLE
wsgi module not always enabled - added section to fix

### DIFF
--- a/cookbooks/openstack/recipes/dashboard.rb
+++ b/cookbooks/openstack/recipes/dashboard.rb
@@ -34,6 +34,12 @@ end
 execute "a2enmod rewrite" do
         command "a2enmod rewrite"
         action :run
+        notifies :restart, resources(:service => "apache2"), :delayed
+end
+
+execute "a2enmod wsgi" do
+        command "a2enmod wsgi"
+        action :run
         notifies :restart, resources(:service => "apache2"), :immediately
 end
 


### PR DESCRIPTION
added section to dash recipe to enable wsgi module. Also changed notify on rewrite module to delayed, until after wsgi is enabled otherwise apache will error on configtest
