### PR TITLE
Fixing metadata

### DIFF
--- a/cookbooks/openstack/metadata.rb
+++ b/cookbooks/openstack/metadata.rb
@@ -12,3 +12,4 @@ end
 
 depends "apt"
 depends "openssh"
+depends "keystone"


### PR DESCRIPTION
...hen runing from chef-server as the keystone cookbook is not pulled down without it.
