### PR TITLE
make dash work

### DIFF
--- a/cookbooks/horizon/recipes/server.rb
+++ b/cookbooks/horizon/recipes/server.rb
@@ -48,7 +48,7 @@ template "/etc/openstack-dashboard/local_settings.py" do
   variables(
             :user => node[:horizon][:db_user],
             :passwd => node[:horizon][:db_passwd],
-            :ip_address => node[:compute][:controller_ipaddress],
+            :ip_address => node[:controller_ipaddress],
             :db_name => node[:horizon][:db],
             :service_port => node[:identity][:service_port],
             :admin_port => node[:identity][:admin_port],


### PR DESCRIPTION
OPENSTACK_HOST needs to be set to nova[:controller_ipaddress], not node[:compute][:controller_ipaddress] which is blank and gets a default of ipaddress which in vagrant returns 10.0.2.15 and keystone binds to 192.168.10.10 under most circumstances
