### PR TITLE
running glance-manage db sync before glance-registry is started causes t...

### DIFF
--- a/cookbooks/glance/recipes/registry.rb
+++ b/cookbooks/glance/recipes/registry.rb
@@ -78,7 +78,7 @@ service glance_registry_service do
 end
 
 execute "glance-manage db_sync" do
-        command "glance-manage db_sync"
+        command "sudo -u glance glance-manage db_sync"
         action :nothing
         notifies :restart, resources(:service => glance_registry_service), :immediately
 end


### PR DESCRIPTION
...he log file to be owned by root and registry fails to start on Fedora
