### PR TITLE
Trailing commas

### DIFF
--- a/roles/jenkins-allinone.rb
+++ b/roles/jenkins-allinone.rb
@@ -7,5 +7,5 @@ default_attributes(
   "mysql" => {
     "allow_remote_root" => true
   },
-  "package_component" => "essex-final",
+  "package_component" => "essex-final"
 )

--- a/roles/nova-api-ec2.rb
+++ b/roles/nova-api-ec2.rb
@@ -3,6 +3,6 @@ description "Nova API EC2"
 run_list(
   "role[base]",
   "recipe[nova::nova-setup]",
-  "recipe[nova::api-ec2]",
+  "recipe[nova::api-ec2]"
 )
 


### PR DESCRIPTION
Remove trailing comments from role files since apparently magic is involved somewhere to make them palatable as JSON
