### PR TITLE
Minor ruby syntax error

### DIFF
--- a/roles/jenkins-nova-api.rb
+++ b/roles/jenkins-nova-api.rb
@@ -1,7 +1,7 @@
 name "jenkins-nova-api"
 description "Jenkins Nova API"
 run_list(
-  "role[nova-api]",
+  "role[nova-api]"
 )
 default_attributes(
   "mysql" => {


### PR DESCRIPTION
fix for jenkins-nova-api.rb

Syntax error because of unneeded comma
