### PR TITLE
Add chef-client cookbook to base role

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "cookbooks/corosync"]
 	path = cookbooks/corosync
 	url = https://github.com/rcbops-cookbooks/corosync.git
+[submodule "cookbooks/chef-client"]
+	path = cookbooks/chef-client
+	url = https://github.com/opscode-cookbooks/chef-client.git

--- a/roles/base.rb
+++ b/roles/base.rb
@@ -7,7 +7,8 @@ run_list(
   "recipe[sosreport]",
   "recipe[rsyslog::default]",
   "recipe[hardware]",
-  "recipe[osops-utils::default]"
+  "recipe[osops-utils::default]",
+  "recipe[chef-client]"
 )
 default_attributes(
   "ntp" => {


### PR DESCRIPTION
This cookbook will configure chef-client as a daemon on the node. I have added it to the base role as well to simplify the deployment process.
