### PR TITLE
include quantum recipes directly in single-network-node. 

### DIFF
--- a/roles/single-network-node.rb
+++ b/roles/single-network-node.rb
@@ -3,6 +3,8 @@ description "Quantum Network Node (non-HA)"
 run_list(
   "role[base]",
   "role[rsyslog-client]",
-  "recipe[nova-network::network-node]",
+  "recipe[nova-network::quantum-metadata-agent]",
+  "recipe[nova-network::quantum-dhcp-agent]",
+  "recipe[nova-network::quantum-plugin]",
   "role[openstack-logging]"
 )


### PR DESCRIPTION
no need for network-node recipe
