### PR TITLE
Add version recipe to base role

### DIFF
--- a/roles/base.rb
+++ b/roles/base.rb
@@ -6,7 +6,7 @@ run_list(
   "recipe[ntp]",
   "recipe[rsyslog::default]",
   "recipe[hardware]",
-  "recipe[osops-utils::default]"
+  "recipe[osops-utils::version]"
 )
 default_attributes(
   "ntp" => {


### PR DESCRIPTION
Add the osops-utils::version recipe to the base role, which will now create an
/etc/rpc-release file with the currently converged version.

rcbops/chef-cookbooks#772
