### PR TITLE
Add version recipe to base role

### DIFF
--- a/roles/base.rb
+++ b/roles/base.rb
@@ -7,7 +7,7 @@ run_list(
   "recipe[ntp]",
   "recipe[rsyslog::default]",
   "recipe[hardware]",
-  "recipe[osops-utils::default]"
+  "recipe[osops-utils::version]"
 )
 default_attributes(
   "ntp" => {


### PR DESCRIPTION
Add the osops-utils::version recipe to the base role, which will now create an
/etc/rpc-release file with the currently converged version.

rcbops/chef-cookbooks#772

(cherry picked from commit 9ccae819e1a73fbce045b1c1a8fde6efca5cbdc9)
