### PR TITLE
Remove modules submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,9 +79,6 @@
 [submodule "cookbooks/rsyslog"]
 	path = cookbooks/rsyslog
 	url = https://github.com/opscode-cookbooks/rsyslog.git
-[submodule "cookbooks/modules"]
-	path = cookbooks/modules
-	url = https://github.com/Youscribe/modules-cookbook
 [submodule "cookbooks/sysctl"]
 	path = cookbooks/sysctl
 	url = https://github.com/rcbops-cookbooks/sysctl.git


### PR DESCRIPTION
We don't use it any more in lieu of some bash, and upstream is out of
date/broken anyways. The sha is also wrong after an upstream force push, which
causes git clone --recursive issues.
- Remove modules submodule from cookbooks
