### PR TITLE
Move cinder scheduler to where volume is located

### DIFF
--- a/roles/cinder-volume.rb
+++ b/roles/cinder-volume.rb
@@ -2,6 +2,7 @@ name "cinder-volume"
 description "Cinder Volume Service"
 run_list(
   "role[base]",
+  "role[cinder-scheduler]",
   "recipe[cinder::cinder-volume]",
   "recipe[openstack-monitoring::cinder-volume]"
 )

--- a/roles/ha-controller1.rb
+++ b/roles/ha-controller1.rb
@@ -22,7 +22,6 @@ run_list(
   "role[nova-api-os-compute]",
   "role[cinder-setup]",
   "role[cinder-api]",
-  "role[cinder-scheduler]",
   "role[ceilometer-setup]",
   "role[ceilometer-api]",
   "role[ceilometer-collector]",

--- a/roles/ha-controller2.rb
+++ b/roles/ha-controller2.rb
@@ -18,7 +18,6 @@ run_list(
   "role[nova-api-os-compute]",
   "role[nova-network-controller]",
   "role[cinder-api]",
-  "role[cinder-scheduler]",
   "role[ceilometer-api]",
   "role[ceilometer-collector]",
   "role[ceilometer-central-agent]",


### PR DESCRIPTION
HA failover causes cinder-volume to stop responding because the
scheduler does not reconnect properly after the vip failover. Since the
scheduler is worthless w/o the volume service anyways, just put it right
there  where the volume is and off of the ha controller 1/2 nodes.

Issue rcbops/chef-cookbooks#942

(cherry picked from commit 74bb5b7e76f1219b684d345a488ae5e3aa5f75ca)
